### PR TITLE
Onboard npm restores to Central Feed Service

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@actions:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@isaacs:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@types:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/

--- a/eng/ci/templates/jobs/build-and-test.yml
+++ b/eng/ci/templates/jobs/build-and-test.yml
@@ -14,6 +14,11 @@ jobs:
         os: ${{ pool.os }}
 
       steps:
+      - task: npmAuthenticate@0
+        inputs:
+          workingFile: '.npmrc'
+        displayName: 'Authenticate npm'
+
       - task: Npm@1
         inputs:
           command: 'install'


### PR DESCRIPTION
## Summary
- route repository-owned npm installs through the `public/upstream-public` Central Feed Service registry
- map every scope in the resolved production dependency graph (`@actions`, `@isaacs`, and `@types`) to CFS
- authenticate the shared Azure Pipelines build job before any npm activity

## Dependency audit
- audited committed manifests, lockfiles, Azure Pipelines and GitHub Actions workflows, templates, scripts, action packaging, and dependency commands
- found one npm project and no NuGet, Python, global npm install, Dockerfile, or detached/copied build-tree dependency paths
- left `package-lock.json` URLs and customer-facing action runtime/package metadata unchanged
- confirmed the package dry-run excludes `.npmrc` and credential-like files

## Validation
- cold-cache `npm ci` through CFS using transient local Azure DevOps authentication
- observed zero direct `registry.npmjs.org` contacts and zero npm errors/401s
- `npm run build`
- `npm test -- --runInBand`
- `npm pack --dry-run --json`

## Caveat
- Azure Pipelines itself was not run locally; the shared job uses `npmAuthenticate@0` with the repository `.npmrc`, matching the existing pipeline task model.